### PR TITLE
fix append followers, add check for non following

### DIFF
--- a/store/article.go
+++ b/store/article.go
@@ -227,9 +227,13 @@ func (as *ArticleStore) ListFeed(userID uint, offset, limit int) ([]model.Articl
 
 	as.db.Model(&u).Preload("Following").Preload("Follower").Association("Followings").Find(&followings)
 
+	if len(followings) == 0 {
+		return articles, 0, nil
+	}
+
 	ids := make([]uint, len(followings))
-	for _, i := range followings {
-		ids = append(ids, i.FollowingID)
+	for i, f := range followings {
+		ids[i] = f.FollowingID
 	}
 
 	as.db.Where("author_id in (?)", ids).


### PR DESCRIPTION
There is no sense to go further if followers not found. So I added check to return empty slice. And there was a bug when appending to slice ids, kinda:
```
ids: [0, 0 , 0] => [0, 0, 0, FollowingID, FollowingID]
```